### PR TITLE
Pass upstream error message on failed unmarshal

### DIFF
--- a/simpleyaml.go
+++ b/simpleyaml.go
@@ -43,7 +43,7 @@ func NewYaml(body []byte) (*Yaml, error) {
 	var val interface{}
 	err := yaml.Unmarshal(body, &val)
 	if err != nil {
-		return nil, errors.New("unmarshal []byte to yaml failed")
+		return nil, errors.New("unmarshal []byte to yaml failed: " + err.Error())
 	}
 	return &Yaml{val}, nil
 }


### PR DESCRIPTION
simpleyaml now passes along the upstream error message
from go-yaml, when it fails to unmarshal data. This
provides better feedback to the end user on why the
unmarshal failed.
