### PR TITLE
fix Get() function. argument type string to interface{}

### DIFF
--- a/simpleyaml.go
+++ b/simpleyaml.go
@@ -52,7 +52,7 @@ func NewYaml(body []byte) (*Yaml, error) {
 //
 // Example:
 //      y.Get("xx").Get("yy").Int()
-func (y *Yaml) Get(key string) *Yaml {
+func (y *Yaml) Get(key interface{}) *Yaml {
 	m, err := y.Map()
 	if err == nil {
 		if val, ok := m[key]; ok {
@@ -66,7 +66,7 @@ func (y *Yaml) Get(key string) *Yaml {
 //
 // Example:
 //      y.GetPath("bb", "cc").Int()
-func (y *Yaml) GetPath(branch ...string) *Yaml {
+func (y *Yaml) GetPath(branch ...interface{}) *Yaml {
 	yin := y
 	for _, p := range branch {
 		yin = yin.Get(p)

--- a/simpleyaml_test.go
+++ b/simpleyaml_test.go
@@ -9,6 +9,7 @@ name: smallfish
 age: 99
 float: 3.14159
 bool: true
+0: IntKey
 emails:
    - xxx@xx.com
    - yyy@yy.com
@@ -48,6 +49,22 @@ func TestString(t *testing.T) {
 	t.Log(v)
 	if v != "smallfish" {
 		t.Fatal("match name failed")
+	}
+}
+
+func TestStringFromIntKey(t *testing.T) {
+	y, err := NewYaml(data)
+	if err != nil {
+		t.Fatal("init yaml failed")
+	}
+	v, err := y.Get(0).String()
+	if err != nil {
+		t.Fatal("get yaml failed")
+	}
+
+	t.Log(v)
+	if v != "IntKey" {
+		t.Fatal("match IntKey failed")
 	}
 }
 
@@ -156,3 +173,4 @@ func TestMap(t *testing.T) {
 		t.Fatal("fail to check number of keys")
 	}
 }
+


### PR DESCRIPTION

This PR replaces the argument of Get function from string type to interface {} type.
In our yaml we have an int type key and we wanted to change because we could not get the data.

Thank you for your consideration.

※Sorry for my poor English.