### PR TITLE
adding recursive method to retrieve all paths from a yaml file

### DIFF
--- a/helper/util/get_paths.go
+++ b/helper/util/get_paths.go
@@ -1,0 +1,62 @@
+package util
+
+import (
+	"errors"
+	"github.com/smallfish/simpleyaml"
+  "strconv"
+  "bytes"
+)
+
+var ArrayOfPaths = make([]string, 0)
+
+func GetAllExistingPaths(y *simpleyaml.Yaml, PathSlice []string) ([]string, error) {
+	if y.IsMap() {
+		keys, err := y.GetMapKeys()
+		if err != nil {
+			return nil, errors.New("Retrieving map keys failed")
+		}
+		for k, _ := range keys {
+			if k != 0 {
+				PathSlice = PathSlice[:len(PathSlice)-1]
+			}
+			PathSlice = append(PathSlice, keys[k])
+			GetAllExistingPaths(y.Get(keys[k]), PathSlice)
+		}
+	} else if y.IsArray() {
+		arr, err := y.Array()
+		if err != nil {
+			return nil, errors.New("Retrieving array failed")
+		}
+		for k, _ := range arr {
+			if k != 0 {
+				PathSlice = PathSlice[:len(PathSlice)-1]
+			}
+			PathSlice = append(PathSlice, strconv.Itoa(k))
+			GetAllExistingPaths(y.GetIndex(k), PathSlice)
+		}
+	} else {
+		var buffer bytes.Buffer
+		for k, _ := range PathSlice {
+				if k == len(PathSlice)-1 {
+				  buffer.WriteString(PathSlice[k])
+				}else{
+				  buffer.WriteString(PathSlice[k]+"/")
+				}
+		}
+		ArrayOfPaths = append(ArrayOfPaths, buffer.String())
+	}
+	return ArrayOfPaths, nil
+}
+
+// GetAllPaths retrieves all possible paths in the YAML file
+//
+// Example:
+//      util.GetAllPaths(*Yaml)
+func GetAllPaths(y *simpleyaml.Yaml) ([]string, error)  {
+	InitialPath := make([]string, 0)
+	AllPaths, err :=  GetAllExistingPaths(y, InitialPath)
+	if err != nil {
+		return nil, errors.New("Retrieving paths failed")
+	}
+	return AllPaths, nil
+}

--- a/simpleyaml.go
+++ b/simpleyaml.go
@@ -31,15 +31,13 @@ package simpleyaml
 
 import (
 	"errors"
-	"strconv"
 	"gopkg.in/yaml.v2"
-	"bytes"
 )
 
 type Yaml struct {
 	data interface{}
 }
-var array_of_paths = make([]string, 0)
+
 // NewYaml returns a pointer to a new `Yaml` object after unmarshaling `body` bytes
 func NewYaml(body []byte) (*Yaml, error) {
 	var val interface{}
@@ -181,56 +179,4 @@ func (y *Yaml) GetMapKeys() ([]string, error) {
 		}
 	}
 	return keys, nil
-}
-
-// GetAllPaths retrieves all possible paths in the YAML file
-//
-// Example:
-//      y.GetAllPaths(yaml_file, array_of_strings)
-func GetAllExistingPaths(y *Yaml, path_slice []string) []string {
-	if y.IsMap() {
-		keys, err := y.GetMapKeys()
-		if err != nil {
-			panic(err)
-		}
-		for k, _ := range keys {
-			if k != 0 {
-				path_slice = path_slice[:len(path_slice)-1]
-			}
-			path_slice = append(path_slice, keys[k])
-			GetAllExistingPaths(y.Get(keys[k]), path_slice)
-		}
-	} else if y.IsArray() {
-		arr, err := y.Array()
-		if err != nil {
-			panic(err)
-		}
-		for k, _ := range arr {
-			if k != 0 {
-				path_slice = path_slice[:len(path_slice)-1]
-			}
-			path_slice = append(path_slice, strconv.Itoa(k))
-			GetAllExistingPaths(y.GetIndex(k), path_slice)
-		}
-	} else {
-		var buffer bytes.Buffer
-		for k, _ := range path_slice {
-				if k == len(path_slice)-1 {
-				  buffer.WriteString(path_slice[k])
-				}else{
-				  buffer.WriteString(path_slice[k]+".")
-				}
-		}
-		array_of_paths = append(array_of_paths, buffer.String())
-	}
-	return array_of_paths
-}
-
-// Helper function to invoke GetAllExistingPaths
-func (y *Yaml) GetAllPaths() []string {
-	yin := y
-	all_paths := make([]string, 0)
-	initial_path := make([]string, 0)
-	all_paths = GetAllExistingPaths(yin, initial_path)
-	return all_paths
 }

--- a/simpleyaml.go
+++ b/simpleyaml.go
@@ -31,13 +31,15 @@ package simpleyaml
 
 import (
 	"errors"
+	"strconv"
 	"gopkg.in/yaml.v2"
+	"bytes"
 )
 
 type Yaml struct {
 	data interface{}
 }
-
+var array_of_paths = make([]string, 0)
 // NewYaml returns a pointer to a new `Yaml` object after unmarshaling `body` bytes
 func NewYaml(body []byte) (*Yaml, error) {
 	var val interface{}
@@ -179,4 +181,56 @@ func (y *Yaml) GetMapKeys() ([]string, error) {
 		}
 	}
 	return keys, nil
+}
+
+// GetAllPaths retrieves all possible paths in the YAML file
+//
+// Example:
+//      y.GetAllPaths(yaml_file, array_of_strings)
+func GetAllExistingPaths(y *Yaml, path_slice []string) []string {
+	if y.IsMap() {
+		keys, err := y.GetMapKeys()
+		if err != nil {
+			panic(err)
+		}
+		for k, _ := range keys {
+			if k != 0 {
+				path_slice = path_slice[:len(path_slice)-1]
+			}
+			path_slice = append(path_slice, keys[k])
+			GetAllExistingPaths(y.Get(keys[k]), path_slice)
+		}
+	} else if y.IsArray() {
+		arr, err := y.Array()
+		if err != nil {
+			panic(err)
+		}
+		for k, _ := range arr {
+			if k != 0 {
+				path_slice = path_slice[:len(path_slice)-1]
+			}
+			path_slice = append(path_slice, strconv.Itoa(k))
+			GetAllExistingPaths(y.GetIndex(k), path_slice)
+		}
+	} else {
+		var buffer bytes.Buffer
+		for k, _ := range path_slice {
+				if k == len(path_slice)-1 {
+				  buffer.WriteString(path_slice[k])
+				}else{
+				  buffer.WriteString(path_slice[k]+".")
+				}
+		}
+		array_of_paths = append(array_of_paths, buffer.String())
+	}
+	return array_of_paths
+}
+
+// Helper function to invoke GetAllExistingPaths
+func (y *Yaml) GetAllPaths() []string {
+	yin := y
+	all_paths := make([]string, 0)
+	initial_path := make([]string, 0)
+	all_paths = GetAllExistingPaths(yin, initial_path)
+	return all_paths
 }

--- a/simpleyaml_test.go
+++ b/simpleyaml_test.go
@@ -141,6 +141,23 @@ func TestGetPath(t *testing.T) {
 	}
 }
 
+func TestGetAllPaths(t *testing.T) {
+	y, err := NewYaml(data)
+	if err != nil {
+		t.Fatal("init yaml failed")
+	}
+
+	v := y.GetAllPaths()
+	if err != nil {
+		t.Fatal("get yaml failed")
+	}
+
+	t.Log(v)
+	if len(v) != 10 {
+		t.Fatal("Number of paths do not match number or real paths.")
+	}
+}
+
 func TestArray(t *testing.T) {
 	y, err := NewYaml(data)
 	if err != nil {

--- a/simpleyaml_test.go
+++ b/simpleyaml_test.go
@@ -1,7 +1,9 @@
-package simpleyaml
+package simpleyaml_test
 
 import (
 	"testing"
+	"github.com/smallfish/simpleyaml"
+	"github.com/smallfish/simpleyaml/helper/util"
 )
 
 var data = []byte(`
@@ -23,7 +25,7 @@ bb:
 `)
 
 func TestBool(t *testing.T) {
-	y, err := NewYaml(data)
+	y, err := simpleyaml.NewYaml(data)
 	if err != nil {
 		t.Fatal("init yaml failed")
 	}
@@ -38,7 +40,7 @@ func TestBool(t *testing.T) {
 }
 
 func TestString(t *testing.T) {
-	y, err := NewYaml(data)
+	y, err := simpleyaml.NewYaml(data)
 	if err != nil {
 		t.Fatal("init yaml failed")
 	}
@@ -53,7 +55,7 @@ func TestString(t *testing.T) {
 }
 
 func TestStringFromIntKey(t *testing.T) {
-	y, err := NewYaml(data)
+	y, err := simpleyaml.NewYaml(data)
 	if err != nil {
 		t.Fatal("init yaml failed")
 	}
@@ -69,7 +71,7 @@ func TestStringFromIntKey(t *testing.T) {
 }
 
 func TestFloat(t *testing.T) {
-	y, err := NewYaml(data)
+	y, err := simpleyaml.NewYaml(data)
 	if err != nil {
 		t.Fatal("init yaml failed")
 	}
@@ -85,7 +87,7 @@ func TestFloat(t *testing.T) {
 }
 
 func TestInt(t *testing.T) {
-	y, err := NewYaml(data)
+	y, err := simpleyaml.NewYaml(data)
 	if err != nil {
 		t.Fatal("init yaml failed")
 	}
@@ -100,7 +102,7 @@ func TestInt(t *testing.T) {
 }
 
 func TestGetIndex(t *testing.T) {
-	y, err := NewYaml(data)
+	y, err := simpleyaml.NewYaml(data)
 	if err != nil {
 		t.Fatal("init yaml failed")
 	}
@@ -112,7 +114,7 @@ func TestGetIndex(t *testing.T) {
 }
 
 func TestString2(t *testing.T) {
-	y, err := NewYaml(data)
+	y, err := simpleyaml.NewYaml(data)
 	if err != nil {
 		t.Fatal("init yaml failed")
 	}
@@ -127,7 +129,7 @@ func TestString2(t *testing.T) {
 }
 
 func TestGetPath(t *testing.T) {
-	y, err := NewYaml(data)
+	y, err := simpleyaml.NewYaml(data)
 	if err != nil {
 		t.Fatal("init yaml failed")
 	}
@@ -142,14 +144,14 @@ func TestGetPath(t *testing.T) {
 }
 
 func TestGetAllPaths(t *testing.T) {
-	y, err := NewYaml(data)
+	y, err := simpleyaml.NewYaml(data)
 	if err != nil {
 		t.Fatal("init yaml failed")
 	}
 
-	v := y.GetAllPaths()
+	v, err := util.GetAllPaths(y)
 	if err != nil {
-		t.Fatal("get yaml failed")
+		t.Fatal("Getting all paths failed")
 	}
 
 	t.Log(v)
@@ -159,7 +161,7 @@ func TestGetAllPaths(t *testing.T) {
 }
 
 func TestArray(t *testing.T) {
-	y, err := NewYaml(data)
+	y, err := simpleyaml.NewYaml(data)
 	if err != nil {
 		t.Fatal("init yaml failed")
 	}
@@ -174,7 +176,7 @@ func TestArray(t *testing.T) {
 }
 
 func TestMap(t *testing.T) {
-	y, err := NewYaml(data)
+	y, err := simpleyaml.NewYaml(data)
 	if err != nil {
 		t.Fatal("init yaml failed")
 	}
@@ -192,7 +194,7 @@ func TestMap(t *testing.T) {
 }
 
 func TestIsFound(t *testing.T) {
-	y, err := NewYaml(data)
+	y, err := simpleyaml.NewYaml(data)
 	if err != nil {
 		t.Fatal("init yaml failed")
 	}


### PR DESCRIPTION
Hi,

Could we have a new invocation called `GetAllPaths()`, that will retrieve all paths in the YAML file. This will be helpful, some use cases I´m thinking are: 
 - comparing YAML files per path (differences, similarities)
 - deleting specific paths based on comparisons

I added a new test case for the function,its just checking if the number of all paths match the number of the array return by the function. Also, I saw that the `GetMapKeys() ` in the test cases,   it´s missing one map(`0: IntKey`)  is this intended?

Regards,
Enrique Encalada